### PR TITLE
Fixes for metadata credential fetching

### DIFF
--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -332,7 +332,8 @@ function execute(session::GoogleSession, resource::APIResource, method::APIMetho
     # https://github.com/JuliaWeb/HTTP.jl/blob/master/src/Messages.jl#L166
     for (key, value) in res.headers 
         if key=="Content-Type" 
-            if value=="application/json"
+            content_type = split(value, ";")[1]
+            if content_type=="application/json"
                 for (k2, v2) in res.headers 
                     if k2=="Content-Length" && v2=="0"
                         return HTTP.nobody 

--- a/src/credentials.jl
+++ b/src/credentials.jl
@@ -58,7 +58,7 @@ function Base.get(credentials::MetadataCredentials, path::AbstractString; contex
     if HTTP.Messages.status(res) != 200
         throw(CredentialError("Unable to obtain credentials from metadata server"))
     end
-    String(res.data)
+    String(res.body)
 end
 
 """


### PR DESCRIPTION
The first change is for a change in the Julia HTTP library, `data` is now `body`.

The second is for a change it the Google API, the format of the `Content-Type` header has changed.

With these two changes, `MetadataCredentials` works on GCE instances.