### PR TITLE
Update MbedTLS compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 HTTP = "0.9"
 JSON = "0.21"
 Libz = "1"
-MbedTLS = "0.6"
+MbedTLS = "1"
 MsgPack = "1"
 julia = "1"
 


### PR DESCRIPTION
Previously #35 proposed updating HTTP and MbedTLS, but in the end the latter was not updated to maintain compatibility with the then-LTS version of Julia. A new LTS version of Julia has since been released, so unless I'm missing something we can now make this change.

This would be nice to have done because the older version of MbedTLS included a somewhat cantankerous build script.

Tests pass for me locally.

If this PR is accepted, then #35 can be closed.