### PR TITLE
Supporting content-type json with encoding specification

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GoogleCloud"
 uuid = "55e21f81-8b0a-565e-b5ad-6816892a5ee7"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -130,7 +130,7 @@ function Base.getindex(store::KeyStore{K, V}, key::K) where {K, V}
     if iserror(data)
         throw(KeyError(key))
     end
-    val = store.reader(data)
+    val = store.reader(String(data))
     convert(V, val)
 end
 
@@ -176,7 +176,7 @@ end
 
 # avoiding race condition where values might have been deleted after keys were generated
 @inline function Base.values(store::KeyStore{K, V}) where {K, V}
-    (x for x in (get(store, key, Nothing) for key in keys(store)) if x !== Voide)
+    (x for x in (get(store, key, Nothing) for key in keys(store)) if !isnothing(x))
 end
 
 function Base.delete!(store::KeyStore{K, V}, key::K) where {K, V}


### PR DESCRIPTION
"Content-Type" sometimes contains not simply "application/json", but an encoding like "application/json; charset=utf8" or whatever. This was breaking requests, works now.

Furthermore, the type of the response is Uint8 instead of string. Not sure what could be the origin of this change, but simply making sure we have a `String` before decoding seems to be fine.

A past refactoring also missed a `Voide` type that was probably a `Void` that should have turned into `Nothing`, or `nothing`, I'm not sure, please let me know if this test is fine. The current code at least runs now in the happy-path.

