### PR TITLE
NoCredentials class for accessing publicly available data

### DIFF
--- a/src/GoogleCloud.jl
+++ b/src/GoogleCloud.jl
@@ -4,7 +4,7 @@ Google Cloud APIs
 module GoogleCloud
 
 export
-    JSONCredentials, MetadataCredentials, GoogleSession, authorize,
+    JSONCredentials, MetadataCredentials, NoCredentials, GoogleSession, authorize,
     set_session!, get_session
 export
     iam, storage, compute, container, pubsub, logging, datastore

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -239,9 +239,13 @@ function execute(session::GoogleSession, resource::APIResource, method::APIMetho
 
     # obtain and use access token
     auth = authorize(session)
-    headers = Dict{String, String}(
-        "Authorization" => "$(auth[:token_type]) $(auth[:access_token])"
-    )
+    headers = if isnothing(auth)
+        Dict{String, String}()
+    else
+        Dict{String, String}(
+            "Authorization" => "$(auth[:token_type]) $(auth[:access_token])"
+        )
+    end
     params = Dict(params)
 
     # check if data provided when not expected
@@ -273,7 +277,7 @@ function execute(session::GoogleSession, resource::APIResource, method::APIMetho
 
     # merge in default parameters and evaluate any expressions
     params = merge!(copy(method.default_params), Dict(params))
-    extra = Dict(:project_id => session.credentials.project_id)
+    extra = hasproperty(session.credentials, :project_id) ? Dict(:project_id => session.credentials.project_id) : Dict()
     for (key, val) in params
         if isa(val, Symbol)
             params[key] = extra[val]

--- a/src/credentials.jl
+++ b/src/credentials.jl
@@ -3,7 +3,7 @@ Google Cloud Platform service-account API credentials.
 """
 module credentials
 
-export Credentials, JSONCredentials, MetadataCredentials
+export Credentials, JSONCredentials, MetadataCredentials, NoCredentials
 
 import Base: show, print
 import JSON
@@ -126,4 +126,8 @@ function print(io::IO, x::Credentials)
 end
 show(io::IO, x::JSONCredentials) = print(io, x)
 
+struct NoCredentials <: Credentials
 end
+
+end
+

--- a/src/session.jl
+++ b/src/session.jl
@@ -195,4 +195,6 @@ function authorize(session::GoogleSession; cache::Bool=true)
     authorization
 end
 
+authorize(session::GoogleSession{T}) where {T <: NoCredentials} = nothing
+
 end

--- a/test/nocredentials.jl
+++ b/test/nocredentials.jl
@@ -6,6 +6,8 @@ using JSON
 creds = NoCredentials()
 
 session = GoogleSession(creds, ["devstorage.full_control"])
+
+## Test download of JSON data from Pong dataset
 bucketName = "atari-replay-datasets"
 prefix="dqn/Pong/1/replay_logs/\$store\$_action"
 
@@ -17,6 +19,13 @@ end
 
 EXPECTED_PARITY = 0xf1
 
-@testset "NoCredentials" begin
+## Test download of binary data from sentinel dataset
+sentinelbucket = "gcp-public-data-sentinel-2"
+sentinelpath = "L2/tiles/32/T/NS/S2A_MSIL2A_20210506T102021_N0300_R065_T32TNS_20210506T132458.SAFE/GRANULE/L2A_T32TNS_A030664_20210506T102022/IMG_DATA/R20m/T32TNS_20210506T102021_B07_20m.jp2"
+sentinelimage = GoogleCloud.storage(:Object, :get, sentinelbucket, sentinelpath; session)
+EXPECTED_PARITY_SENTINEL = 0x6e
+
+@testset "storage access and NoCredentials" begin
     @test reduce(⊻, fetch.(parities)) == EXPECTED_PARITY
+    @test reduce(⊻, sentinelimage) == EXPECTED_PARITY_SENTINEL
 end

--- a/test/nocredentials.jl
+++ b/test/nocredentials.jl
@@ -3,14 +3,16 @@ using Test
 using GoogleCloud
 using JSON
 
-creds = NoCredentials()
+@testset "NoCredentials" begin
+    creds = NoCredentials()
 
-session = GoogleSession(creds, ["devstorage.full_control"])
-bucketName = "atari-replay-datasets"
-fileList = GoogleCloud.storage(:Object, :list, bucketName; prefix="dqn/Pong/1/replay_logs/\$store\$_action", session=session) |> IOBuffer |> JSON.parse
+    session = GoogleSession(creds, ["devstorage.full_control"])
+    bucketName = "atari-replay-datasets"
+    fileList = GoogleCloud.storage(:Object, :list, bucketName; prefix="dqn/Pong/1/replay_logs/\$store\$_action", session=session) |> IOBuffer |> JSON.parse
 
-parities = map(fileList["items"]) do item
-    reduce(⊻, GoogleCloud.storage(:Object, :get, bucketName, item["name"], session=session))
+    parities = map(fileList["items"]) do item
+        reduce(⊻, GoogleCloud.storage(:Object, :get, bucketName, item["name"], session=session))
+    end
+
+    @test reduce(⊻, fetch.(parities)) == 0xf1
 end
-
-@test reduce(⊻, fetch.(parities)) == 0xf1

--- a/test/nocredentials.jl
+++ b/test/nocredentials.jl
@@ -1,0 +1,16 @@
+using Test
+
+using GoogleCloud
+using JSON
+
+creds = NoCredentials()
+
+session = GoogleSession(creds, ["devstorage.full_control"])
+bucketName = "atari-replay-datasets"
+fileList = GoogleCloud.storage(:Object, :list, bucketName; prefix="dqn/Pong/1/replay_logs/\$store\$_action", session=session) |> IOBuffer |> JSON.parse
+
+parities = map(fileList["items"]) do item
+    reduce(⊻, GoogleCloud.storage(:Object, :get, bucketName, item["name"], session=session))
+end
+
+@test reduce(⊻, fetch.(parities)) == 0xf1

--- a/test/nocredentials.jl
+++ b/test/nocredentials.jl
@@ -3,16 +3,17 @@ using Test
 using GoogleCloud
 using JSON
 
+creds = NoCredentials()
+
+session = GoogleSession(creds, ["devstorage.full_control"])
+bucketName = "atari-replay-datasets"
+@show mydata = GoogleCloud.storage(:Object, :list, bucketName; prefix="dqn/Pong/1/replay_logs/\$store\$_action", session=session)
+fileList = JSON.parse(IOBuffer(mydata))
+
+parities = map(fileList["items"]) do item
+    reduce(⊻, GoogleCloud.storage(:Object, :get, bucketName, item["name"], session=session))
+end
+
 @testset "NoCredentials" begin
-    creds = NoCredentials()
-
-    session = GoogleSession(creds, ["devstorage.full_control"])
-    bucketName = "atari-replay-datasets"
-    fileList = GoogleCloud.storage(:Object, :list, bucketName; prefix="dqn/Pong/1/replay_logs/\$store\$_action", session=session) |> IOBuffer |> JSON.parse
-
-    parities = map(fileList["items"]) do item
-        reduce(⊻, GoogleCloud.storage(:Object, :get, bucketName, item["name"], session=session))
-    end
-
     @test reduce(⊻, fetch.(parities)) == 0xf1
 end

--- a/test/nocredentials.jl
+++ b/test/nocredentials.jl
@@ -7,13 +7,16 @@ creds = NoCredentials()
 
 session = GoogleSession(creds, ["devstorage.full_control"])
 bucketName = "atari-replay-datasets"
-@show mydata = GoogleCloud.storage(:Object, :list, bucketName; prefix="dqn/Pong/1/replay_logs/\$store\$_action", session=session)
-fileList = JSON.parse(IOBuffer(mydata))
+prefix="dqn/Pong/1/replay_logs/\$store\$_action"
 
-parities = map(fileList["items"]) do item
-    reduce(⊻, GoogleCloud.storage(:Object, :get, bucketName, item["name"], session=session))
+fileList = GoogleCloud.storage(:Object, :list, bucketName; prefix, session)
+
+parities = map(fileList) do item
+    reduce(⊻, GoogleCloud.storage(:Object, :get, bucketName, item[:name]; session))
 end
 
+EXPECTED_PARITY = 0xf1
+
 @testset "NoCredentials" begin
-    @test reduce(⊻, fetch.(parities)) == 0xf1
+    @test reduce(⊻, fetch.(parities)) == EXPECTED_PARITY
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,5 @@ using GoogleCloud
 using Test 
 
 include("api.jl")
+include("nocredentials.jl")
 #include("storage.jl")


### PR DESCRIPTION
`NoCredentials` simply omits the "Authorization" header, and works with publicly available data. Something similar is actually offered in the C++ GCP API.