### PR TITLE
[FEATURE] Wrapper for Google Calendar API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,9 @@ version = "0.11.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Libz = "2ec943e9-cfe8-584d-b93d-64dcb6d567b7"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.11.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/src/GoogleCloud.jl
+++ b/src/GoogleCloud.jl
@@ -18,6 +18,7 @@ include("credentials.jl")
 include("session.jl")
 include("api/api.jl")
 include("collection.jl")
+include("api/calendar.jl")
 
 using .error
 using .credentials

--- a/src/api/calendar.jl
+++ b/src/api/calendar.jl
@@ -1,0 +1,121 @@
+module Calendar
+
+    module Calendars
+        using HTTP 
+        using JSON3 
+
+        """
+
+            get(calendar_id, key, client_id, access_token, accept = "application/json", authorization = "Bearer")  
+
+        Returns metadata for a calendar. 
+
+        # Arguments
+        
+        - `calendar_id` - Calendar identifier; if you want to access the primary calendar of the currently logged in user, assign this argument to "primary"
+        - `client_id` - client identifier set-up for your GCP project
+        - `access_token` - OAuth 2.0 access token for user of GCP project 
+        - `accept` - what sort of payload to expect in header; default: "application/json"
+        - `authorization` - authorization type; default: "Bearer"
+
+        # Return 
+
+        - Calendar resource with the following fields:
+          - `kind` - type of the resource 
+          - `etag` - Etage of the resource
+          - `id` - Identifier of the calendar
+          - `summary` - Title of the calendar
+          - `description` - Description of the calendar
+          - `location` - geographic location of the calendar as free-form text
+          - `timeZone` - The time zone of the calendar (formatted as an IANA Time Zone Database name, e.g. "Europe/Zurich")
+          - `conferenceProperties` - Conferencing properties for this calendar, for example what types of conferences are allowed
+        """
+        function get(calendar_id, key, client_id, access_token, accept = "application/json", authorization = "Bearer")
+
+            url = "https://www.googleapis.com/calendar/v3/calendars/"
+
+            headers = [
+                        "Authorization" => "$authorization $access_token",
+                        "client_id" => client_id,
+                        "Accept" => accept 
+                      ] 
+
+            HTTP.get(url * calendar_id * "?key=$key", headers = headers)
+
+        end
+        
+    end
+
+    module Events 
+        using HTTP 
+        using JSON3 
+
+        function get(calendar_id, event_id, key, client_id, access_token, accept = "application/json", authorization = "Bearer"; max_attendees = nothing)
+
+            url = "https://www.googleapis.com/calendar/v3/calendars/$calendar_id/events?key=$key"
+
+            kwarg_dict = Dict("maxAttendees" => max_attendees)
+
+            for (k, v) in kwarg_dict
+                if !isnothing(v) && !isempty(v)
+                    url = url * "&$k=$v"
+                end
+            end
+
+            headers = [
+                        "Authorization" => "$authorization $access_token",
+                        "client_id" => client_id,
+                        "Accept" => accept 
+                      ] 
+
+            HTTP.get(url, headers = headers)
+
+        end
+
+        function list(calendar_id, key, client_id, access_token, accept = "application/json", authorization = "Bearer"; event_types = nothing, ical_uid = nothing, max_results = nothing, order_by = nothing, page_token = nothing, private_extended_property = nothing, q = nothing, shared_extended_property = nothing, show_deleted = nothing, single_events = nothing, show_hidden_invitations = nothing, sync_token = nothing, time_max = nothing, time_min = nothing, max_attendees = nothing, time_zone = nothing, updated_min = nothing)
+
+            url = "https://www.googleapis.com/calendar/v3/calendars/$calendar_id/events?key=$key"
+
+            kwarg_dict = Dict("eventTypes" => event_types, "iCalUID" => ical_uid, "maxAttendees" => max_attendees, "maxResults" => max_results, "orderBy" => order_by, "pageToken" => page_token, "privateExtendedProperty" => private_extended_property, "q" => q, "sharedExtendedProperty" => shared_extended_property, "showDeleted" => show_deleted, "showHiddenInvitations" => show_hidden_invitations, "singleEvents" => single_events, "syncToken" => sync_token, "timeMax" => time_max, "timeMin" => time_min, "timeZone" => time_zone, "updatedMin" => updated_min)
+
+            for (k, v) in kwarg_dict
+                if !isnothing(v) && !isempty(v)
+                    url = url * "&$k=$v"
+                end
+            end
+
+            headers = [
+                        "Authorization" => "$authorization $access_token",
+                        "client_id" => client_id,
+                        "Accept" => accept 
+                      ] 
+
+            HTTP.get(url, headers = headers)
+
+        end
+
+        function instances(calendar_id, event_id, key, client_id, access_token, accept = "application/json", authorization = "Bearer"; max_attendees = nothing, max_results = nothing, original_start = nothing, page_token = nothing, show_deleted = nothing, time_max = nothing, time_min = nothing, time_zone = nothing)
+
+            url = "https://www.googleapis.com/calendar/v3/calendars/$calendar_id/events/$event_id/instances?key=$key"
+
+            kwarg_dict = Dict("maxAttendees" => max_attendees, "timeZone" => time_zone, "maxResults" => max_results, "originalStart" => original_start, "pageToken" => page_token, "showDeleted" => show_deleted, "timeMax" => time_max, "timeMin" => time_min)
+
+            for (k, v) in kwarg_dict
+                if !isnothing(v) && !isempty(v)
+                    url = url * "&$k=$v"
+                end
+            end
+
+            headers = [
+                        "Authorization" => "$authorization $access_token",
+                        "client_id" => client_id,
+                        "Accept" => accept 
+                      ] 
+
+            HTTP.get(url, headers = headers)
+
+        end
+        
+    end
+    
+end


### PR DESCRIPTION
Hi GoogleCloud Maintainers,

I apologize for the random PR out of the blue but I had the impression that GoogleCloud.jl would be the ideal place to contribute new features/wrappers too for the suite of Google Cloud Platform products based on the documentation. I have been developing some "homemade" features for Google Calendar's API that utilizes HTTP payloads. I opened this PR in the hopes of building out support for this API within GoogleCloud.jl as I need it for another project. Here is how it currently can be invoked:

```julia
import Google: Calendar.Calendars

calendar_id = "primary"
key = "API KEY"
client_id = "GCP Client ID"
access_token = "ya29. ... REST OF ACCESS TOKEN"

Calendars.get(calendar_id, key, client_id, access_token)
```

Which would return a JSON Calendar Resource payload that could be parsed via JSON3 or otherwise:

```
HTTP.Messages.Response:
"""
HTTP/1.1 200 OK
Expires: Wed, 31 May 2023 20:04:14 GMT
Date: Wed, 31 May 2023 20:04:14 GMT
Content-Type: application/json; charset=UTF-8
Content-Length: 326
Cache-Control: private, max-age=0, must-revalidate, no-transform
ETag: "redacted"
Vary: Origin, X-Origin, Referer
Server: ESF
X-XSS-Protection: 0
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000

{
 "kind": "calendar#calendar",
 "etag": "\"redacted\"",
 "id": "redacted",
 "summary": "JZ Calendar",
 "description": "My main calendar - where all the magic happens",
 "timeZone": "America/New_York",
 "conferenceProperties": {
  "allowedConferenceSolutionTypes": [
   "hangoutsMeet"
  ]
 }
}
"""
```

---

I paused for now in adding any additional features/functionality as I wanted to get some feedback before proceeding and also ran into some issues on integrating with the rest of GoogleCloud.jl. Here were the points I was thinking about and wanted get y'all's feedback on:

1. How can I set-up authentication using the package already? I want to use the authentication tools you have but I am unsure how to generate access tokens and integrate with the functions I have already built.
2. If you look at the functions I created, I basically created a 1-to-1 wrapper to the calendar API's corresponding function. I was rather ham-fisted with just manually mapping everything over but am not too sure if there is a more elegant way to build GET/POST requests via HTTP.jl (I was looking at the `query` kwarg but I am not sure if that would be too low-level).
3. I don't know how to build effective tests for this module -- would we want to set-up a dummy account for testing or how would you all do it?
4. I introduced submodules to organize things better since in this case, I found multiple dispatch (in a rare circumstance) a bit more convoluted here than having a more OOP/module based approach.

I apologize if this should not be supported within GoogleCloud.jl but I thought I'd try adding here first before making a separate package for the calendar. Otherwise, I look forward to your feedback! Thanks!